### PR TITLE
Fix for switching between focused date selection sets

### DIFF
--- a/src/state/StateReducer.ts
+++ b/src/state/StateReducer.ts
@@ -284,15 +284,14 @@ export function stateReducer(
             selectionSetsStore: {
               ...state.schedule.selectionSetsStore,
               //... but the hover selection is added to the focused selection set of the schedule
-              [state.schedule.focusedSelectionSetId]: new DateSelectionSet({
+              [state.focusedSelectionSetId]: new DateSelectionSet({
                 ...state.schedule.selectionSetsStore[
-                  state.schedule.focusedSelectionSetId
+                  state.focusedSelectionSetId
                 ],
               }).addDateSelectionToSet(
                 state.hoverSelection as CompleteDateSelection,
               ),
             },
-            focusedSelectionSetId: state.schedule.focusedSelectionSetId,
           }),
           hoverSelection: new DateSelection(),
           mouseOverListening: false,

--- a/src/utils/DateSelectionSet.ts
+++ b/src/utils/DateSelectionSet.ts
@@ -150,10 +150,6 @@ export default class DateSelectionSet {
       }
     }
 
-    console.log('removeDateSelectionFromSet::', {
-      previousSelections: this.dateSelections,
-      newSelections: finalDateSelections,
-    });
     this.dateSelections = finalDateSelections;
   }
 

--- a/src/utils/Schedule.ts
+++ b/src/utils/Schedule.ts
@@ -3,17 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 export interface ScheduleProps {
   selectionSetsStore?: { [id: string]: DateSelectionSet };
-  focusedSelectionSetId?: string;
 }
 
 export default class Schedule {
   selectionSetsStore: { [id: string]: DateSelectionSet } = {};
-  focusedSelectionSetId: string;
 
-  constructor({
-    selectionSetsStore = {},
-    focusedSelectionSetId,
-  }: ScheduleProps = {}) {
+  constructor({ selectionSetsStore = {} }: ScheduleProps = {}) {
     // if a valid selectionSetsStore is not provided, initialize a new one
     if (Object.keys(selectionSetsStore).length === 0) {
       const initialSelectionSetUUID = uuidv4();
@@ -23,10 +18,6 @@ export default class Schedule {
     } else {
       this.selectionSetsStore = selectionSetsStore;
     }
-
-    // if a focusedSelectionSetId is not provided, set it to the first selection set in the schedule
-    this.focusedSelectionSetId =
-      focusedSelectionSetId ?? Object.keys(this.selectionSetsStore)[0];
   }
 
   addNewSelectionSet(selectionSet: DateSelectionSet): Schedule {

--- a/src/utils/Schedule.ts
+++ b/src/utils/Schedule.ts
@@ -30,11 +30,9 @@ export default class Schedule {
   }
 
   addNewSelectionSet(selectionSet: DateSelectionSet): Schedule {
-    const newSelectionSetId = uuidv4();
-    this.selectionSetsStore[newSelectionSetId] = selectionSet;
+    this.selectionSetsStore[selectionSet.id] = selectionSet;
     return new Schedule({
       selectionSetsStore: this.selectionSetsStore,
-      focusedSelectionSetId: newSelectionSetId,
     });
   }
 }


### PR DESCRIPTION
- removed duplicate variables in state storing the focused selection set ID (legacy conflict)
- corrected the id used to index selectionSetsStore generated when creating a new selection set. Previously the object key did not equal the actual selection set id, causing issues down the line