### PR TITLE
Fix merging multiple overlapping date selections

### DIFF
--- a/src/state/StateReducer.ts
+++ b/src/state/StateReducer.ts
@@ -277,6 +277,10 @@ export function stateReducer(
     }
     case 'SAVE_HOVER_SELECTION':
       if (state.hoverSelection.isComplete()) {
+        const newCompleteSelection = new CompleteDateSelection(
+          state.hoverSelection.edgeDates as [Date, Date],
+        );
+
         // a copy of current state...
         return new DatePickerState({
           ...state,
@@ -288,9 +292,7 @@ export function stateReducer(
                 ...state.schedule.selectionSetsStore[
                   state.focusedSelectionSetId
                 ],
-              }).addDateSelectionToSet(
-                state.hoverSelection as CompleteDateSelection,
-              ),
+              }).addDateSelectionToSet(newCompleteSelection),
             },
           }),
           hoverSelection: new DateSelection(),

--- a/src/utils/DateSelection.ts
+++ b/src/utils/DateSelection.ts
@@ -124,6 +124,18 @@ export class CompleteDateSelection extends DateSelection {
   isDateInSelection(date: Date) {
     return date >= this.openingDate && date <= this.closingDate;
   }
+
+  merge(selection: CompleteDateSelection) {
+    const newOpeningDate =
+      this.openingDate < selection.openingDate
+        ? this.openingDate
+        : selection.openingDate;
+    const newClosingDate =
+      this.closingDate > selection.closingDate
+        ? this.closingDate
+        : selection.closingDate;
+    return new CompleteDateSelection([newOpeningDate, newClosingDate]);
+  }
 }
 
 export default DateSelection;

--- a/src/utils/DateSelectionSet.ts
+++ b/src/utils/DateSelectionSet.ts
@@ -47,10 +47,9 @@ export default class DateSelectionSet {
     // check if the ranges overlap
     const finalDateSelections: CompleteDateSelection[] = [];
     let aggregateDateSelection = mergedDateSelections[0];
-
-    mergedDateSelections.forEach((currentSelection, index) => {
-      if (index === 0) return; // Skip the first element as it's already set as aggregateDateSelection
-
+    let index = 1;
+    while (index < mergedDateSelections.length) {
+      const currentSelection = mergedDateSelections[index];
       const previousSelection = mergedDateSelections[index - 1];
 
       // if the closing date of the previous selection is greater than the opening date of the current selection, merge them
@@ -58,18 +57,19 @@ export default class DateSelectionSet {
         previousSelection.closingDate.getTime() >=
         currentSelection.openingDate.getTime()
       ) {
-        aggregateDateSelection = new CompleteDateSelection([
-          previousSelection.openingDate,
-          currentSelection.closingDate,
-        ]);
-        // else, push the merged selectionsand start a new aggregate selection
+        aggregateDateSelection = previousSelection.merge(currentSelection);
+        mergedDateSelections.splice(index, 1); // remove the current selection (already included in the aggregate)
+
+        // else, push the aggregated selections and start a new aggregate with the current one
       } else {
         finalDateSelections.push(aggregateDateSelection);
         aggregateDateSelection = currentSelection;
+        index++;
       }
-    });
+    }
 
-    finalDateSelections.push(aggregateDateSelection); // Push the last aggregate selection
+    // Push the last aggregate selection
+    finalDateSelections.push(aggregateDateSelection);
 
     return new DateSelectionSet({
       id: this.id,


### PR DESCRIPTION
- after recognizing an overlap between 2 selections in a set, create an aggregate selection and **remove one of the previous selections** (as it is now included in the aggregate)
- go to next index only if no overlap was detected (and therefore no element was removed from the array we're iterating over)
